### PR TITLE
コンポーネント設計レポート3本を追加

### DIFF
--- a/docs/component-design-report/01-atomic-design.md
+++ b/docs/component-design-report/01-atomic-design.md
@@ -1,0 +1,387 @@
+# Atomic Design コンポーネント設計レポート
+
+| 項目 | 内容 |
+|------|------|
+| プロジェクト名 | TechProfile Pro |
+| ドキュメント種別 | コンポーネント設計レポート |
+| 作成日 | 2026-03-20 |
+
+---
+
+## 1. Atomic Design の採用方針
+
+本プロジェクトでは Brad Frost が提唱した **Atomic Design** をベースに、UIコンポーネントを3階層で構造化している。Atomic Design 本来の5階層（Atoms → Molecules → Organisms → Templates → Pages）から、Templates 層を省略し、Pages は Next.js App Router の `page.tsx` が担う構成としている。
+
+```
+src/components/
+├── atoms/          ← 最小単位の汎用UIパーツ（4コンポーネント）
+│   ├── Badge.tsx
+│   ├── Button.tsx
+│   ├── Input.tsx
+│   └── TextArea.tsx
+├── molecules/      ← Atoms を組み合わせた複合コンポーネント（3コンポーネント）
+│   ├── CareerCard.tsx
+│   ├── SkillCard.tsx
+│   └── SocialLinks.tsx
+└── organisms/      ← 独立した機能単位のコンポーネント（2コンポーネント）
+    ├── ContactForm.tsx
+    └── Header.tsx
+```
+
+---
+
+## 2. Atoms（原子コンポーネント）
+
+Atoms は **単一の HTML 要素をラップ** し、プロジェクト固有のスタイルと Props インターフェースを提供する最小単位のコンポーネントである。
+
+### 2.1 共通設計原則
+
+| 原則 | 実装方法 |
+|------|---------|
+| Props 拡張 | 対応する HTML 要素の属性型を `extends` して継承（例: `ButtonHTMLAttributes<HTMLButtonElement>`） |
+| スタイル合成 | `cn()` ユーティリティでベーススタイル + バリアント + カスタムクラスを結合 |
+| ref 転送 | フォーム要素（Button, Input, TextArea）は `React.forwardRef` で ref を外部公開 |
+| className 拡張 | 全コンポーネントで `className` Props を受け取り、外部からのスタイル追加を許容 |
+
+### 2.2 Button
+
+**ファイル**: `src/components/atoms/Button.tsx`
+
+| Props | 型 | デフォルト | 説明 |
+|-------|-----|----------|------|
+| `variant` | `'primary' \| 'secondary' \| 'outline' \| 'ghost'` | `'primary'` | 外観バリアント |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | サイズ |
+| `isLoading` | `boolean` | `false` | ローディング状態（スピナー表示 + disabled） |
+| `children` | `ReactNode` | - | ボタンテキスト |
+
+**バリアント定義（オブジェクトマップ方式）**:
+
+```typescript
+const variants = {
+    primary: 'glass-card bg-gradient-to-r from-primary-500 to-purple-500 ...',
+    secondary: 'glass-effect text-white ...',
+    outline: 'glass-effect border-2 border-primary-400/50 ...',
+    ghost: 'text-secondary-300 hover:bg-white/10 ...',
+};
+```
+
+バリアントとサイズをオブジェクトマップで管理し、`cn()` で結合するパターンは、条件分岐の複雑化を防ぎ、新しいバリアント追加も容易にする。
+
+**ローディング状態**:
+- `isLoading=true` 時、SVG スピナーアニメーション + `disabled` を自動適用
+- ボタンテキストの左にスピナーを配置（`animate-spin`）
+
+**forwardRef**: あり — `React.forwardRef<HTMLButtonElement, ButtonProps>`
+
+### 2.3 Input
+
+**ファイル**: `src/components/atoms/Input.tsx`
+
+| Props | 型 | 説明 |
+|-------|-----|------|
+| `label` | `string?` | ラベルテキスト（`required` 時に赤アスタリスク表示） |
+| `error` | `string?` | エラーメッセージ（赤テキスト、エラー時ボーダー赤） |
+| `hint` | `string?` | ヒントテキスト（エラー非表示時のみ表示） |
+
+**エラー状態のスタイル切替**:
+
+```typescript
+const hasError = !!error;
+// cn() でエラー状態に応じてボーダー・フォーカスリングの色を切替
+cn(
+    'glass-effect rounded-xl ...',
+    hasError
+        ? 'border-red-400/50 focus:ring-red-400/50'
+        : 'border-white/20 focus:ring-primary-400/50',
+    className,
+)
+```
+
+エラー状態を `boolean` フラグに変換し、`cn()` の条件分岐で赤系/通常系のスタイルを切り替えている。`error` と `hint` は排他表示（error 優先）。
+
+**forwardRef**: あり — `React.forwardRef<HTMLInputElement, InputProps>`
+
+### 2.4 TextArea
+
+**ファイル**: `src/components/atoms/TextArea.tsx`
+
+Input と同一のインターフェース設計。追加で `min-h-[120px]` と `resize-y` を適用。エラー処理・ヒント表示のロジックも Input と同一パターンで実装されている。
+
+**forwardRef**: あり — `React.forwardRef<HTMLTextAreaElement, TextAreaProps>`
+
+### 2.5 Badge
+
+**ファイル**: `src/components/atoms/Badge.tsx`
+
+| Props | 型 | デフォルト | 説明 |
+|-------|-----|----------|------|
+| `variant` | `'default' \| 'secondary' \| 'accent' \| 'outline'` | `'default'` | カラーバリアント |
+| `size` | `'sm' \| 'md'` | `'md'` | サイズ |
+
+**特徴**: Badge は表示専用コンポーネントであるため、`forwardRef` は未使用。`HTMLDivElement` の属性を継承し、`div` 要素としてレンダリングする。`hover:scale-105` によるホバー効果と `glass-effect` ベースのスタイルを持つ。
+
+---
+
+## 3. Molecules（分子コンポーネント）
+
+Molecules は **Atoms や基本要素を組み合わせた複合コンポーネント** である。独自の状態管理は持たず、Props 経由でデータを受け取り表示する。
+
+### 3.1 CareerCard
+
+**ファイル**: `src/components/molecules/CareerCard.tsx`
+
+**依存 Atom**: `Badge`
+
+| Props | 型 | 説明 |
+|-------|-----|------|
+| `title` | `string` | プロジェクトタイトル |
+| `period` | `string` | 期間（フォーマット済み） |
+| `teamSize` | `string` | チーム規模 |
+| `description` | `string` | 説明 |
+| `techStack` | `string[]` | 技術スタック（Badge で表示） |
+| `phases` | `string[]` | 担当フェーズ（Badge で表示） |
+| `role` | `string` | 役割 |
+| `isCurrent` | `boolean?` | 現在進行中フラグ |
+
+**構造**:
+
+```
+CareerCard (glass-card + floating-card)
+├── ヘッダー部
+│   ├── タイトル（hover で neon-text）
+│   ├── 期間（SVG カレンダーアイコン付き）
+│   ├── チーム規模（SVG ユーザーアイコン付き）
+│   └── 「現在」Badge（isCurrent=true 時、animate-pulse）
+├── 区切り線（グラデーション）
+├── 説明文
+├── 技術スタック（Badge variant="secondary" の列挙）
+├── 担当フェーズ（Badge variant="outline" の列挙）
+├── 役割
+└── 下部ホバーライン（scaleX(0) → scaleX(100) アニメーション）
+```
+
+**ホバーエフェクト**:
+- `floating-card` クラスによるカード全体の浮き上がり
+- 下部のグラデーションラインが `group-hover:scale-x-100` で伸びる
+- タイトルが `group-hover:neon-text` で発光テキストに変化
+
+### 3.2 SkillCard
+
+**ファイル**: `src/components/molecules/SkillCard.tsx`
+
+**依存**: `next/image`（Next.js Image コンポーネント）
+
+| Props | 型 | 説明 |
+|-------|-----|------|
+| `name` | `string` | スキル名 |
+| `description` | `string` | 説明テキスト |
+| `iconUrl` | `string` | アイコン画像URL |
+| `className` | `string?` | 追加CSSクラス（アニメーション用） |
+| `style` | `CSSProperties?` | インラインスタイル（animationDelay 用） |
+
+**特徴**:
+- `className` と `style` Props を公開し、親コンポーネント（`page.tsx`）からアニメーション制御を注入可能
+- アイコンの背景にグラデーション（`from-primary-400 to-purple-400`）をオーバーレイ
+- CareerCard と同様の `floating-card` + 下部ホバーラインパターン
+
+### 3.3 SocialLinks
+
+**ファイル**: `src/components/molecules/SocialLinks.tsx`
+
+**依存**: `next/image`、`SNSItem` 型（`@/types/portfolio`）
+
+| Props | 型 | デフォルト | 説明 |
+|-------|-----|----------|------|
+| `links` | `SNSItem[]` | - | SNSリンクデータ配列 |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | アイコンサイズ |
+
+**サイズマッピング**:
+
+```typescript
+const sizes = {
+    sm: { container: 'w-6 h-6', width: 24, height: 24 },
+    md: { container: 'w-8 h-8', width: 32, height: 32 },
+    lg: { container: 'w-10 h-10', width: 40, height: 40 },
+};
+```
+
+**セキュリティ対策**:
+- 全外部リンクに `target="_blank"` + `rel="noopener noreferrer"` を適用
+- `aria-label` に「{SNS名}のプロフィールを開く」を設定（アクセシビリティ）
+
+**ホバーエフェクト**: 白色オーバーレイ（`absolute inset-0 bg-white opacity-0 → opacity-20`）+ `scale-110`
+
+---
+
+## 4. Organisms（生体コンポーネント）
+
+Organisms は **独自の状態管理・イベント処理・API通信を持つ** 複合的な機能コンポーネントである。
+
+### 4.1 Header
+
+**ファイル**: `src/components/organisms/Header.tsx`
+
+**依存 Atom**: なし（純粋な HTML 要素のみ）
+
+| Props | 型 | 説明 |
+|-------|-----|------|
+| `navItems` | `Array<{name: string, href: string}>` | ナビゲーション項目 |
+| `logo` | `string` | ロゴテキスト |
+
+**内部状態**:
+
+| State | 型 | 用途 |
+|-------|-----|------|
+| `isScrolled` | `boolean` | スクロール位置に応じたスタイル切替 |
+| `isMobileMenuOpen` | `boolean` | モバイルメニューの開閉制御 |
+
+**cn() の活用（4箇所）**:
+
+Header コンポーネントは `cn()` を最も多用するコンポーネントであり、スクロール状態に応じた動的なスタイル切替に活用している。
+
+```typescript
+// ヘッダー全体: スクロール状態でガラスエフェクト or 透明
+cn('fixed top-0 ...', isScrolled ? 'glass-effect shadow-glass' : 'bg-transparent')
+
+// ロゴ: スクロール状態でテキストスタイル変化
+cn('font-bold ...', isScrolled ? 'text-primary-400' : 'neon-text')
+
+// ナビ項目: スクロール状態で文字色変化
+cn('transition-all ...', isScrolled ? 'text-white ...' : 'text-secondary-200 ...')
+```
+
+**スクロール検知**:
+- `useEffect` で `scroll` イベントリスナーを登録
+- 閾値 `10px` を超えた場合に `isScrolled` を `true` に設定
+- クリーンアップ関数でリスナーを解除
+
+### 4.2 ContactForm
+
+**ファイル**: `src/components/organisms/ContactForm.tsx`
+
+**依存 Atom**: `Button`, `Input`, `TextArea`
+
+**内部状態**:
+
+| State | 型 | 用途 |
+|-------|-----|------|
+| `isSubmitting` | `boolean` | 送信中状態 |
+| `isSubmitted` | `boolean` | 送信完了状態 |
+| `submitError` | `string \| null` | エラーメッセージ |
+| React Hook Form | `useForm<ContactFormInput>` | フォーム入力値・バリデーション状態 |
+
+**フォーム管理**: React Hook Form + Zod（`@hookform/resolvers/zod`）
+
+```typescript
+const { register, handleSubmit, formState: { errors }, reset } = useForm<ContactFormInput>({
+    resolver: zodResolver(ContactFormSchema),
+});
+```
+
+**Atoms との統合**: `register()` が返す `ref` を Atom の `forwardRef` 経由で DOM 要素に渡す。
+
+```tsx
+<Input
+    label="お名前"
+    required
+    {...register('name')}    // ← register() の戻り値（ref 含む）を展開
+    error={errors.name?.message}
+/>
+```
+
+この統合が成立するために、Input / TextArea / Button の各 Atom が `React.forwardRef` を使用している。
+
+**画面遷移（3状態）**:
+
+```
+[フォーム表示] → 送信 → [送信中（ローディング）] → 成功 → [送信完了画面]
+                                                  → 失敗 → [エラー表示 + フォーム]
+```
+
+---
+
+## 5. ページレベルの組み立て（page.tsx）
+
+`src/app/page.tsx` は `'use client'` ディレクティブによるクライアントコンポーネントであり、全ての Atoms / Molecules / Organisms を組み合わせてポートフォリオサイト全体を構成する。
+
+### 5.1 コンポーネント依存ツリー
+
+```
+page.tsx
+├── Header (organism)
+│   └── [navItems, logo] ← portfolioData.navbar_data から生成
+├── Hero Section（直接実装）
+│   └── Button (atom) ← CTA ボタン
+├── About Section（直接実装）
+│   ├── SocialLinks (molecule) ← portfolioData.about_data.sns_list
+│   └── next/image ← プロフィール画像
+├── Career Section（直接実装）
+│   └── CareerCard (molecule) × N件
+│       └── Badge (atom) ← 技術スタック・フェーズ表示
+├── Skills Section（直接実装）
+│   └── SkillCard (molecule) × 最大N件（段階表示）
+│       └── next/image ← スキルアイコン
+├── Contact Section（直接実装）
+│   └── ContactForm (organism)
+│       ├── Input (atom) ← 名前・メール入力
+│       ├── TextArea (atom) ← メッセージ入力
+│       └── Button (atom) ← 送信ボタン
+└── Footer（直接実装）
+```
+
+### 5.2 状態管理
+
+| State / Ref | 型 | 管理対象 |
+|-------------|-----|---------|
+| `portfolioData` | `useState<PortfolioData \| null>` | API取得データ |
+| `loading` | `useState<boolean>` | ローディング状態 |
+| `visibleSkillsCount` | `useState<number>` | スキル表示件数（初期値: 9） |
+| `prevVisibleCountRef` | `useRef<number>` | 前回表示件数（アニメーション制御用） |
+
+### 5.3 Atomic Design の階層関係
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    Page (page.tsx)                    │
+│    データ取得 / 状態管理 / セクションレイアウト          │
+├─────────────────────────────────────────────────────┤
+│              Organisms（独立機能単位）                 │
+│    Header: スクロール検知 + ナビゲーション制御          │
+│    ContactForm: フォーム管理 + API通信                │
+├─────────────────────────────────────────────────────┤
+│              Molecules（複合表示部品）                 │
+│    CareerCard: Badge を使った経歴情報表示              │
+│    SkillCard: Image を使ったスキル情報表示             │
+│    SocialLinks: Image を使ったSNSリンク一覧           │
+├─────────────────────────────────────────────────────┤
+│               Atoms（最小UIパーツ）                   │
+│    Button / Input / TextArea / Badge                │
+│    → forwardRef / cn() / variant パターン            │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. 設計上の特徴と考察
+
+### 6.1 採用しているパターン
+
+| パターン | 実装箇所 | 効果 |
+|---------|---------|------|
+| **バリアントマップ** | Button, Badge | `if/else` の乱立を防ぎ、バリアント追加を容易にする |
+| **サイズマップ** | Button, Badge, SocialLinks | サイズごとのスタイル定義を一箇所に集約 |
+| **グループホバー** | CareerCard, SkillCard | `group` + `group-hover:` でカード内要素のホバー連動を実現 |
+| **条件付き cn()** | Header, Input, TextArea | 状態に応じたスタイル切替を宣言的に記述 |
+| **Props スプレッド** | 全 Atoms | `{...props}` で HTML ネイティブ属性をすべて透過 |
+| **displayName** | forwardRef 使用 Atoms | React DevTools でのデバッグ容易性を確保 |
+
+### 6.2 階層間の責務分離
+
+| 階層 | 責務 | 状態管理 | 外部通信 |
+|------|------|---------|---------|
+| Atoms | 単一要素のスタイル・インタラクション | なし | なし |
+| Molecules | 複数要素の組み合わせ表示 | なし | なし |
+| Organisms | 機能ロジック（フォーム、ナビ） | あり（useState, useEffect） | あり（API通信） |
+| Page | 全体レイアウト + データ取得 | あり（useState, useRef） | あり（fetch） |
+
+この分離により、Atoms / Molecules はステートレスで再利用性が高く、ビジネスロジックは Organisms / Page に集約されている。

--- a/docs/component-design-report/02-cn-utility.md
+++ b/docs/component-design-report/02-cn-utility.md
@@ -1,0 +1,222 @@
+# cn() ユーティリティ設計レポート
+
+| 項目 | 内容 |
+|------|------|
+| プロジェクト名 | TechProfile Pro |
+| ドキュメント種別 | cn() ユーティリティ設計レポート |
+| 作成日 | 2026-03-20 |
+
+---
+
+## 1. cn() の定義と役割
+
+### 1.1 ソースコード
+
+**ファイル**: `src/utils/cn.ts`
+
+```typescript
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}
+```
+
+### 1.2 処理の流れ
+
+```
+入力: cn('px-4 text-white', isError && 'text-red-400', className)
+        │
+        ▼
+    clsx(inputs)
+    ・falsy 値（false, null, undefined）を除去
+    ・配列・オブジェクトを展開
+    ・有効なクラス名を半角スペースで結合
+        │
+        ▼
+    twMerge(result)
+    ・Tailwind CSS クラスの競合を検出・解決
+    ・例: 'px-4 px-6' → 'px-6'（後勝ち）
+    ・例: 'text-white text-red-400' → 'text-red-400'（後勝ち）
+        │
+        ▼
+出力: 最終的なクラス名文字列
+```
+
+### 1.3 2つのライブラリの役割分担
+
+| ライブラリ | 役割 | 解決する問題 |
+|-----------|------|-------------|
+| **clsx** | 条件付きクラス名の結合 | `false && 'hidden'` のような条件式を安全に処理 |
+| **tailwind-merge** | Tailwind クラスの競合解決 | `'px-4 px-6'` で `px-4` が残ってしまう問題を解決 |
+
+**clsx だけでは不十分な例**:
+
+```typescript
+// clsx のみ
+clsx('px-4', 'px-6')  // → 'px-4 px-6'（両方残る → CSS 詳細度の問題）
+
+// cn() (clsx + tailwind-merge)
+cn('px-4', 'px-6')    // → 'px-6'（後のクラスが優先される）
+```
+
+---
+
+## 2. 使用パターン一覧
+
+### 2.1 全使用箇所
+
+| ファイル | cn() 呼び出し数 | 主な用途 |
+|---------|----------------|---------|
+| `atoms/Button.tsx` | 1 | ベース + バリアント + サイズ + 条件 + className |
+| `atoms/Input.tsx` | 1 | ベース + エラー状態条件 + className |
+| `atoms/TextArea.tsx` | 1 | ベース + エラー状態条件 + className |
+| `atoms/Badge.tsx` | 1 | ベース + バリアント + サイズ + className |
+| `molecules/CareerCard.tsx` | 1 | ベース + className |
+| `molecules/SkillCard.tsx` | 1 | ベース + className |
+| `molecules/SocialLinks.tsx` | 2 | コンテナレイアウト + アイコンサイズ |
+| `organisms/Header.tsx` | 4 | スクロール状態に応じた動的スタイル切替 |
+| **合計** | **12** | |
+
+### 2.2 パターン別分類
+
+#### パターン A: バリアント + サイズ + className 結合
+
+**使用箇所**: Button, Badge
+
+```typescript
+// Button.tsx
+cn(baseStyles, variants[variant], sizes[size], isLoading && '...', className)
+```
+
+**構造**:
+```
+cn(
+    固定ベーススタイル,      // 'rounded-xl font-semibold ...'
+    バリアントマップ[値],     // variants['primary'] → 'glass-card bg-gradient-to-r ...'
+    サイズマップ[値],         // sizes['md'] → 'h-10 px-4 text-base'
+    条件付きクラス,           // isLoading && 'cursor-not-allowed'
+    外部からの className      // 親コンポーネントによるカスタマイズ
+)
+```
+
+**特徴**: オブジェクトマップでバリアントとサイズを管理し、`cn()` で結合する。新しいバリアント追加はマップに1行追加するだけで完了する。
+
+#### パターン B: 条件分岐によるスタイル切替
+
+**使用箇所**: Input, TextArea, Header
+
+```typescript
+// Input.tsx
+cn(
+    'glass-effect rounded-xl px-4 py-3 ...',
+    hasError
+        ? 'border-red-400/50 focus:ring-red-400/50'
+        : 'border-white/20 focus:ring-primary-400/50',
+    className,
+)
+```
+
+**特徴**: 三項演算子で状態に応じたスタイルセットを丸ごと切り替える。`clsx` の条件処理と `twMerge` のクラス競合解決が連携することで、安全にスタイルを上書きできる。
+
+#### パターン C: 固定ベース + className 透過
+
+**使用箇所**: CareerCard, SkillCard
+
+```typescript
+// CareerCard.tsx
+cn('glass-card floating-card overflow-hidden ...', className)
+```
+
+**特徴**: コンポーネント固有のベーススタイルを定義しつつ、`className` Props でアニメーションクラス等を外部から注入できるようにしている。SkillCard では `animate-fade-in-up` をこの方式で注入している。
+
+#### パターン D: 複数インスタンスでの動的切替
+
+**使用箇所**: Header（4箇所）
+
+```typescript
+// Header.tsx — ヘッダー全体
+cn(
+    'fixed top-0 left-0 right-0 z-50 transition-all duration-300',
+    isScrolled
+        ? 'glass-effect shadow-glass border-b border-white/10'
+        : 'bg-transparent',
+)
+
+// Header.tsx — ロゴ
+cn(
+    'font-bold tracking-wider ...',
+    isScrolled ? 'text-primary-400' : 'neon-text',
+)
+
+// Header.tsx — ナビ項目
+cn(
+    'transition-all duration-200 ...',
+    isScrolled
+        ? 'text-white hover:text-primary-400'
+        : 'text-secondary-200 hover:text-white',
+)
+```
+
+**特徴**: 同一の `isScrolled` 状態を参照して、ヘッダー内の複数要素のスタイルを一貫して切り替える。`cn()` がなければ各要素に `style` 属性か個別の条件ロジックが必要になる。
+
+---
+
+## 3. cn() がない場合の比較
+
+### 3.1 素の className 結合との比較
+
+```typescript
+// cn() を使わない場合
+<button
+    className={`rounded-xl font-semibold ${
+        variant === 'primary'
+            ? 'glass-card bg-gradient-to-r from-primary-500 to-purple-500'
+            : variant === 'secondary'
+            ? 'glass-effect text-white'
+            : ''
+    } ${size === 'sm' ? 'h-8 px-3 text-sm' : 'h-10 px-4 text-base'} ${
+        isLoading ? 'cursor-not-allowed' : ''
+    } ${className || ''}`}
+/>
+
+// cn() を使う場合
+<button className={cn(baseStyles, variants[variant], sizes[size], isLoading && '...', className)} />
+```
+
+### 3.2 cn() の利点まとめ
+
+| 利点 | 説明 |
+|------|------|
+| **可読性** | テンプレートリテラルのネストがなくなり、意図が明確 |
+| **安全性** | `false`, `null`, `undefined` を自動除去（余分なスペースやリテラル "false" が入らない） |
+| **Tailwind 競合解決** | `className` Props で渡されたクラスが内部クラスと競合しても正しく上書きされる |
+| **保守性** | バリアント・サイズの追加がオブジェクトマップへの1行追加で完結 |
+
+---
+
+## 4. className Props の設計意図
+
+全コンポーネントが `className` Props を受け取り `cn()` の最後の引数に渡す設計には、以下の意図がある。
+
+```typescript
+// コンポーネント内部
+cn(内部スタイル, ..., className)  // className は最後に渡す
+```
+
+**`className` を最後に渡す理由**:
+- `tailwind-merge` は後に記述されたクラスを優先する
+- 外部から渡されたクラスが内部のデフォルトスタイルを確実に上書きできる
+
+**実例（page.tsx → SkillCard）**:
+
+```tsx
+// page.tsx
+<SkillCard
+    className={isNew ? 'animate-fade-in-up' : ''}  // アニメーション注入
+    style={isNew ? { animationDelay: `${(index - prev) * 0.1}s` } : undefined}
+/>
+```
+
+SkillCard 内部の `cn('glass-card floating-card ...', className)` により、`animate-fade-in-up` が追加クラスとして適用される。

--- a/docs/component-design-report/03-forward-ref.md
+++ b/docs/component-design-report/03-forward-ref.md
@@ -1,0 +1,312 @@
+# React.forwardRef 設計レポート
+
+| 項目 | 内容 |
+|------|------|
+| プロジェクト名 | TechProfile Pro |
+| ドキュメント種別 | React.forwardRef 設計レポート |
+| 作成日 | 2026-03-20 |
+
+---
+
+## 1. forwardRef の概要と本プロジェクトでの必要性
+
+### 1.1 React.forwardRef とは
+
+`React.forwardRef` は、親コンポーネントから子コンポーネント内部の DOM 要素に `ref` を渡すための React API である。通常、`ref` は Props として転送されないため、カスタムコンポーネントの内部 DOM 要素にアクセスするにはこの仕組みが必要になる。
+
+### 1.2 本プロジェクトで forwardRef が必要な理由
+
+本プロジェクトでは、お問い合わせフォーム（`ContactForm`）で **React Hook Form** を使用している。React Hook Form の `register()` 関数は、フォーム要素への `ref` を返す。この `ref` を通じて以下の処理を行う:
+
+- フォーム要素の値の取得・設定
+- フォーカス制御（バリデーションエラー時のフォーカス移動）
+- DOM イベントのリスナー登録
+
+```
+React Hook Form の register()
+        │
+        │ { ref, onChange, onBlur, name } を返す
+        ▼
+    <Input {...register('name')} />
+        │
+        │ ref を Input 内部の <input> 要素に転送する必要がある
+        ▼
+    React.forwardRef で ref を透過
+        │
+        ▼
+    <input ref={ref} /> ← DOM 要素に直接アタッチ
+```
+
+**forwardRef がないと**: `register()` が返す `ref` がカスタムコンポーネントで止まり、内部の `<input>` 要素に到達しない。React Hook Form はフォーム要素を認識できず、バリデーションやフォーカス管理が動作しなくなる。
+
+---
+
+## 2. 実装されているコンポーネント
+
+### 2.1 対象コンポーネント一覧
+
+| コンポーネント | HTML 要素 | forwardRef 型引数 | displayName |
+|--------------|----------|-------------------|-------------|
+| `Button` | `<button>` | `React.forwardRef<HTMLButtonElement, ButtonProps>` | `'Button'` |
+| `Input` | `<input>` | `React.forwardRef<HTMLInputElement, InputProps>` | `'Input'` |
+| `TextArea` | `<textarea>` | `React.forwardRef<HTMLTextAreaElement, TextAreaProps>` | `'TextArea'` |
+
+### 2.2 forwardRef を使用しないコンポーネント
+
+| コンポーネント | 理由 |
+|--------------|------|
+| `Badge` | 表示専用。外部から DOM 要素にアクセスする必要がない |
+| `CareerCard` | 表示専用。フォーム要素を含まない |
+| `SkillCard` | 表示専用。フォーム要素を含まない |
+| `SocialLinks` | リンク表示専用。外部からの ref 制御不要 |
+| `Header` | Organism。内部で状態管理を完結している |
+| `ContactForm` | Organism。内部で React Hook Form を使用し、Atoms に ref を渡す側 |
+
+**判断基準**: フォーム要素（`<input>`, `<textarea>`, `<button>`）をラップする Atom コンポーネントのみが `forwardRef` を使用する。
+
+---
+
+## 3. 実装パターンの詳細
+
+### 3.1 共通パターン
+
+3つのコンポーネントは同一の実装パターンに従っている。
+
+```typescript
+// ① Props 型定義 — HTML 要素のネイティブ属性を継承
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    label?: string;
+    error?: string;
+    hint?: string;
+}
+
+// ② forwardRef でコンポーネントを定義
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+    ({ label, error, hint, className, required, ...props }, ref) => {
+        //       ↑ カスタム Props を分割代入        ↑ ref は第2引数
+
+        return (
+            <div>
+                {label && <label>...</label>}
+                <input
+                    ref={ref}         // ③ ref を DOM 要素に渡す
+                    className={cn(...);}
+                    {...props}        // ④ 残りの HTML 属性をすべて透過
+                />
+                {error && <p>...</p>}
+            </div>
+        );
+    },
+);
+
+// ⑤ displayName を設定（React DevTools 対応）
+Input.displayName = 'Input';
+```
+
+### 3.2 各ステップの解説
+
+#### ① Props 型の継承
+
+```typescript
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> { ... }
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> { ... }
+interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> { ... }
+```
+
+HTML 要素のネイティブ属性型を `extends` することで、`onClick`, `disabled`, `placeholder`, `type` 等の標準属性をすべて Props として受け取れる。カスタム Props（`label`, `error`, `variant` 等）のみを明示的に定義すればよい。
+
+#### ② forwardRef の型引数
+
+```typescript
+React.forwardRef<HTMLButtonElement, ButtonProps>(...)
+//                ↑ ref の対象型         ↑ Props 型
+```
+
+- 第1型引数: `ref` が指す DOM 要素の型
+- 第2型引数: コンポーネントの Props 型
+
+これにより、TypeScript が `ref.current` のプロパティや Props を正確に型チェックする。
+
+#### ③ ref の転送
+
+```typescript
+<input ref={ref} ... />
+```
+
+`forwardRef` の第2引数として受け取った `ref` を、内部の DOM 要素に直接渡す。これにより、親コンポーネントが `ref` を通じてこの `<input>` 要素にアクセスできる。
+
+#### ④ Props のスプレッド
+
+```typescript
+const { label, error, hint, className, required, ...props } = props;
+// カスタム Props を取り出し、残り（HTML ネイティブ属性）を ...props に集約
+<input {...props} />
+// ネイティブ属性をすべて DOM 要素に透過
+```
+
+**重要**: カスタム Props（`label`, `error` 等）を分割代入で取り出さないと、`<input label="..." error="...">` のように無効な HTML 属性が DOM に渡されてしまう。
+
+#### ⑤ displayName の設定
+
+```typescript
+Input.displayName = 'Input';
+```
+
+`forwardRef` で作成したコンポーネントは、デフォルトでは React DevTools に `ForwardRef` と表示される。`displayName` を設定することで、`Input` と表示され、デバッグが容易になる。
+
+---
+
+## 4. ContactForm での統合フロー
+
+### 4.1 React Hook Form との接続
+
+```tsx
+// ContactForm.tsx（Organism）
+const { register, handleSubmit, formState: { errors }, reset } = useForm<ContactFormInput>({
+    resolver: zodResolver(ContactFormSchema),
+});
+
+// register('name') は以下のオブジェクトを返す:
+// { ref: (element) => void, onChange: ..., onBlur: ..., name: 'name' }
+
+<Input
+    label="お名前"
+    required
+    placeholder="山田 太郎"
+    {...register('name')}        // ref, onChange, onBlur, name が展開される
+    error={errors.name?.message}
+/>
+```
+
+### 4.2 データフロー図
+
+```
+ContactForm (Organism)
+    │
+    │ useForm({ resolver: zodResolver(ContactFormSchema) })
+    │
+    ├── register('name') → { ref, onChange, onBlur, name }
+    │       │
+    │       ▼
+    │   <Input {...register('name')} error={errors.name?.message}>
+    │       │
+    │       │ forwardRef で ref を転送
+    │       ▼
+    │   <input ref={ref} onChange={onChange} onBlur={onBlur} name="name" />
+    │       │
+    │       │ ユーザー入力イベント
+    │       ▼
+    │   React Hook Form が値を追跡
+    │
+    ├── register('email') → { ref, onChange, onBlur, name }
+    │       │
+    │       ▼
+    │   <Input {...register('email')} error={errors.email?.message}>
+    │       │
+    │       ▼
+    │   <input ref={ref} type="email" ... />
+    │
+    └── register('message') → { ref, onChange, onBlur, name }
+            │
+            ▼
+        <TextArea {...register('message')} error={errors.message?.message}>
+            │
+            ▼
+        <textarea ref={ref} ... />
+```
+
+### 4.3 バリデーション時のフォーカス制御
+
+React Hook Form は `ref` を通じてバリデーションエラー時に該当フィールドへ自動フォーカスを移動する機能を持つ。
+
+```
+ユーザーが「送信」ボタンをクリック
+    │
+    ▼
+handleSubmit が Zod スキーマでバリデーション実行
+    │
+    ├── 成功 → onSubmit コールバック実行
+    │
+    └── 失敗 → errors オブジェクトにエラーを格納
+              │
+              ├── errors.name → Input に error Props として渡される
+              │                 → 赤ボーダー + エラーメッセージ表示
+              │
+              └── React Hook Form が ref 経由で
+                  最初のエラーフィールドにフォーカスを移動
+                  （shouldFocusError オプション）
+```
+
+この自動フォーカス移動が正しく機能するためには、`forwardRef` による ref 転送が不可欠である。
+
+---
+
+## 5. forwardRef と Atoms / Organisms の責務分離
+
+### 5.1 設計上の位置づけ
+
+```
+┌──────────────────────────────────────────────────────┐
+│ ContactForm (Organism)                                │
+│   責務: フォームロジック、バリデーション、API通信          │
+│   所有: useForm, register(), handleSubmit()            │
+│                                                      │
+│   ┌──────────────────────────────────────────────┐   │
+│   │ Input (Atom)                                  │   │
+│   │   責務: 見た目（スタイル、ラベル、エラー表示）      │   │
+│   │   forwardRef: register() の ref を <input> に転送 │   │
+│   │   → ロジックは持たない、ref を透過するだけ          │   │
+│   └──────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────┘
+```
+
+**Atom の役割**: ref を受け取り、内部の DOM 要素に転送するだけ。バリデーションロジックやフォーム状態は一切知らない。
+
+**Organism の役割**: React Hook Form を通じてフォーム全体を管理し、`register()` の戻り値を各 Atom に渡す。
+
+この分離により、Input / TextArea は ContactForm 以外の文脈でも再利用可能であり、逆に ContactForm は Input の内部実装に依存しない。
+
+### 5.2 Button の forwardRef
+
+Button も `forwardRef` を使用しているが、現時点では ContactForm 内で `register()` を通じた ref 転送は行っていない（送信ボタンは `type="submit"` で、React Hook Form がフォームの `onSubmit` イベントで処理する）。
+
+Button に `forwardRef` が実装されている理由:
+- 将来的にプログラム的なフォーカス制御やクリックトリガーが必要になった場合に備える
+- Atom コンポーネントとしての一貫性（フォーム要素系 Atom は全て forwardRef 対応）
+- 外部からの DOM アクセスを許容する設計方針
+
+---
+
+## 6. まとめ: 3つの要素の連携
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   コンポーネント設計の3本柱                      │
+│                                                             │
+│  ┌────────────────┐                                         │
+│  │  Atomic Design  │ → コンポーネントの階層構造を定義           │
+│  │  atoms/         │   Atoms: 最小パーツ（Button, Input...）  │
+│  │  molecules/     │   Molecules: 複合表示（Card 系）         │
+│  │  organisms/     │   Organisms: 機能単位（Form, Header）    │
+│  └───────┬────────┘                                         │
+│          │                                                  │
+│  ┌───────▼────────┐                                         │
+│  │     cn()       │ → 全階層でスタイルを安全に合成             │
+│  │  clsx +        │   バリアント切替、条件付きクラス、           │
+│  │  tailwind-merge│   className Props の透過を実現            │
+│  └───────┬────────┘                                         │
+│          │                                                  │
+│  ┌───────▼────────┐                                         │
+│  │  forwardRef    │ → Atoms と Organisms の間で ref を橋渡し   │
+│  │  Button        │   React Hook Form の register() が       │
+│  │  Input         │   Atom 内部の DOM 要素に到達可能にする      │
+│  │  TextArea      │                                         │
+│  └────────────────┘                                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **Atomic Design** がコンポーネントの責務と階層を定義し
+- **cn()** が各階層でのスタイル合成を安全に行い
+- **forwardRef** が階層を跨いだ DOM アクセスを可能にする
+
+この3つの要素が連携することで、再利用性・型安全性・保守性の高いコンポーネントアーキテクチャが実現されている。


### PR DESCRIPTION
## Summary
- Atomic Design（atoms → molecules → organisms）の階層構造・全9コンポーネントの設計詳細をレポート
- cn() ユーティリティ（clsx + tailwind-merge）の全12箇所の使用パターンを4分類で整理
- React.forwardRef による React Hook Form 統合フローを図解付きで文書化

## 追加ファイル
- `docs/component-design-report/01-atomic-design.md`
- `docs/component-design-report/02-cn-utility.md`
- `docs/component-design-report/03-forward-ref.md`

## Test plan
- [ ] 各 Markdown ファイルが正しくレンダリングされることを確認
- [ ] コードブロック・テーブル・図が崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)