### PR TITLE
fix: Dockerfileのruntimeステージにpnpmを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN pnpm run build
 # =======================================================================
 FROM node:18-alpine
 
+# pnpm を有効化
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
 # 作業ディレクトリを設定
 WORKDIR /app
 


### PR DESCRIPTION
## 原因

マルチステージビルドの実行フェーズ（runtime stage）に pnpm がインストールされていなかった。

- ビルドステージでは `corepack enable` で pnpm を有効化済み
- しかし runtime stage は新しい `node:18-alpine` イメージのため pnpm が存在しない
- `CMD ["pnpm", "run", "start"]` が実行できずコンテナ起動失敗 → Cloud Run デプロイ失敗

## 修正内容

runtime stage にも `corepack enable && corepack prepare pnpm@10.33.0 --activate` を追加。

## Test plan

- [ ] Docker ビルドが成功することを確認
- [ ] Cloud Run デプロイが成功することを確認（GitHub Actions）

🤖 Generated with [Claude Code](https://claude.com/claude-code)