### PR TITLE
ci: PR で type-check/lint/format を実行し JSDoc lint を導入

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -54,6 +54,21 @@ export async function resolveDisplayName(
 }
 ```
 
-## Lint による強制（推奨）
+## Lint による強制（導入済み）
 
-`eslint-plugin-jsdoc` を導入し、公開シンボルへの JSDoc 欠落・`@param` / `@returns` 漏れを CI で検出する。TypeScript プロジェクトでは型ブレース系ルールを無効化する（`jsdoc/require-param-type` / `jsdoc/require-returns-type` を off）。
+`eslint-plugin-jsdoc`（ESLint 8 互換の v48 系）を導入し、`.eslintrc.json` の `overrides` で `src/**/*.{ts,tsx}` に機械判定可能なルールを適用している。`settings.jsdoc.mode: "typescript"` で TS モードを有効化。
+
+| ルール | レベル | 目的 |
+|---|---|---|
+| `jsdoc/no-types` | error | 型の再掲を禁止（TS シグネチャが型の唯一の真実） |
+| `jsdoc/require-param` | error | JSDoc ブロックを持つ関数は全引数を `@param` で説明（分割代入 props は型が真実のため展開しない: `checkDestructured: false`） |
+| `jsdoc/require-param-description` | error | `@param` に説明文を必須化 |
+| `jsdoc/check-param-names` | error | `@param` 名と実引数名の突き合わせ（名前ズレ・順序・過不足を検出） |
+| `jsdoc/require-returns` | error | 返り値がある関数は `@returns` を必須化（後述の `.tsx` を除く） |
+| `jsdoc/require-returns-description` | error | `@returns` に説明文を必須化 |
+| `jsdoc/check-alignment` | warn | JSDoc ブロックの体裁を整える |
+| `jsdoc/no-multi-asterisks` | warn | アスタリスクの重複を検出 |
+
+- **`.tsx`（React コンポーネント）は `require-returns` / `require-returns-description` を off**: JSX を返す要素に「@returns …の要素」を書くのはノイズになるため。`.ts`（フック / lib / API）では `@returns` 必須のまま。
+- `require-jsdoc` は行コメント（`//`）を誤検知するため未採用。JSDoc ブロックの有無・質はレビューで確認する（＝コメント無しの既存コードは lint を壊さない）。
+- 参考: 上記方針は `youtube-my-collection`（ESLint 9 フラット config）を ESLint 8 レガシー config 向けに移植したもの。

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,5 +6,39 @@
         "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-explicit-any": "warn",
         "prefer-const": "error"
-    }
+    },
+    "overrides": [
+        {
+            "files": ["src/**/*.ts", "src/**/*.tsx"],
+            "plugins": ["jsdoc"],
+            "settings": {
+                "jsdoc": {
+                    "mode": "typescript"
+                }
+            },
+            "rules": {
+                "jsdoc/no-types": "error",
+                "jsdoc/require-param": [
+                    "error",
+                    {
+                        "checkDestructured": false,
+                        "checkDestructuredRoots": false
+                    }
+                ],
+                "jsdoc/require-param-description": "error",
+                "jsdoc/check-param-names": "error",
+                "jsdoc/require-returns": "error",
+                "jsdoc/require-returns-description": "error",
+                "jsdoc/check-alignment": "warn",
+                "jsdoc/no-multi-asterisks": "warn"
+            }
+        },
+        {
+            "files": ["src/**/*.tsx"],
+            "rules": {
+                "jsdoc/require-returns": "off",
+                "jsdoc/require-returns-description": "off"
+            }
+        }
+    ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch:
+
+jobs:
+    quality:
+        name: Quality checks
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Type check (tsc --noEmit)
+              run: pnpm type-check
+
+            - name: Lint (ESLint + JSDoc)
+              run: pnpm lint
+
+            - name: Format check (Prettier)
+              run: pnpm format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,19 @@
+# 依存関係・ビルド成果物
+node_modules/
+.next/
+out/
+build/
+next-env.d.ts
+
+# パッケージマネージャのロックファイル（pnpm が管理）
+pnpm-lock.yaml
+
+# 手書きの Markdown ドキュメント・プロジェクトメタ（Prettier 管理外）
+*.md
+docs/
+.claude/
+
+# GitHub 設定（ワークフロー YAML は Prettier 管理外）
+.github/
+
+LICENSE

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -754,13 +754,15 @@ handlers.ts で定義すべきハンドラー:
 
 ```
 テスト実行フロー:
-  1. 型チェック (tsc --noEmit)
-  2. リント (next lint)
-  3. フォーマットチェック (prettier --check .)
-  4. ユニットテスト + 統合テスト (vitest run --coverage)
-  5. ビルド (next build)
-  6. E2Eテスト (playwright test)
+  1. 型チェック (tsc --noEmit)          ← 実装済み（ci.yml）
+  2. リント (next lint)                 ← 実装済み（ci.yml。ESLint + JSDoc）
+  3. フォーマットチェック (prettier --check .)  ← 実装済み（ci.yml。.prettierignore でコードのみ対象）
+  4. ユニットテスト + 統合テスト (vitest run --coverage)  ← 未実装（テスト未導入）
+  5. ビルド (next build)                 ← デプロイ時に実行（deploy_to_googlecloud.yml）
+  6. E2Eテスト (playwright test)         ← 未実装
 ```
+
+> **現状**: 上記 1〜3（型チェック・Lint・フォーマットチェック）は `main` 宛 PR で走る `ci.yml` として実装済み。4・6 のテスト系はテストランナー未導入のため未実装（`docs/08` §1.1 参照）。5 のビルドはデプロイワークフロー内で実行される。
 
 ### 9.2 実行条件
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -142,6 +142,7 @@
 | eslint-config-next | 14.2.5 | Next.js 用 ESLint 設定 |
 | @typescript-eslint/eslint-plugin | ^7.18.0 | TypeScript ESLint プラグイン |
 | @typescript-eslint/parser | ^7.18.0 | TypeScript ESLint パーサー |
+| eslint-plugin-jsdoc | ^48.11.0 | JSDoc（TSDoc）コメントの静的検査（`src/**` の TS/TSX 対象。ESLint 8 互換のため v48 系を採用） |
 | prettier | ^3.3.2 | コードフォーマッター |
 
 ### 2.3 動作環境要件

--- a/docs/10-miscellaneous-specification.md
+++ b/docs/10-miscellaneous-specification.md
@@ -192,6 +192,7 @@ pnpm dev
 | 未使用変数 | エラー（`@typescript-eslint/no-unused-vars: "error"`） |
 | any 型の使用 | 警告（`@typescript-eslint/no-explicit-any: "warn"`） |
 | const 優先 | 必須（`prefer-const: "error"`） |
+| JSDoc（TSDoc） | `eslint-plugin-jsdoc` で `src/**` の TS/TSX を静的検査（型再掲禁止・`@param`/`@returns` 必須。`.tsx` は `@returns` を除外）。詳細は `.claude/rules/jsdoc.md` |
 | モジュール | ESModules（`"module": "esnext"`） |
 | ターゲット | ES5（`"target": "es5"`） |
 | パスエイリアス | `@/*` は `./src/*` にマッピング |
@@ -311,11 +312,26 @@ main（本番）
 
 ### 5.4 CI/CD パイプライン
 
-`main` ブランチへのプッシュ時に GitHub Actions が以下を自動実行する:
+GitHub Actions は 2 本のワークフローで構成する。
+
+#### CI（品質チェック / `.github/workflows/ci.yml`）
+
+`main` 宛の **Pull Request**（および手動実行 `workflow_dispatch`）で以下を実行する。いずれか失敗するとチェックが赤くなり、マージ前に検知できる。
+
+1. コードのチェックアウト
+2. pnpm / Node.js 20 のセットアップ（依存キャッシュ有効）
+3. 依存インストール（`pnpm install --frozen-lockfile`）
+4. 型チェック（`pnpm type-check` = `tsc --noEmit`）
+5. Lint（`pnpm lint` = ESLint + JSDoc ルール。エラーで失敗、警告は許容）
+6. フォーマットチェック（`pnpm format:check` = Prettier。`.prettierignore` で docs / lockfile / `.github` を除外し、コードのみ対象）
+
+#### Deploy（`.github/workflows/deploy_to_googlecloud.yml`）
+
+`main` ブランチへのプッシュ時に以下を自動実行する:
 
 1. コードのチェックアウト
 2. Google Cloud 認証
-3. Docker イメージのビルド
+3. Docker イメージのビルド（`next build` 実行時に ESLint エラーがあれば失敗）
 4. Artifact Registry へのプッシュ
 5. Cloud Run へのデプロイ
 6. 古いイメージのクリーンアップ（最新5件を保持）

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "autoprefixer": "10.4.19",
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.5",
+        "eslint-plugin-jsdoc": "^48.11.0",
         "postcss": "8.4.38",
         "prettier": "^3.3.2",
         "tailwindcss": "3.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       eslint-config-next:
         specifier: 14.2.5
         version: 14.2.5(eslint@8.57.0)(typescript@5.5.2)
+      eslint-plugin-jsdoc:
+        specifier: ^48.11.0
+        version: 48.11.0(eslint@8.57.0)
       postcss:
         specifier: 8.4.38
         version: 8.4.38
@@ -90,6 +93,10 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@es-joy/jsdoccomment@0.46.0':
+    resolution: {integrity: sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==}
+    engines: {node: '>=16'}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -246,6 +253,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.1.2':
+    resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@react-email/render@1.1.2':
     resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
@@ -543,6 +554,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -718,6 +733,10 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -860,6 +879,9 @@ packages:
     resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -940,6 +962,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-jsdoc@48.11.0:
+    resolution: {integrity: sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -966,11 +994,19 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -1381,6 +1417,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@4.0.0:
+    resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
+    engines: {node: '>=12.0.0'}
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -1612,6 +1652,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-imports@2.2.1:
+    resolution: {integrity: sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==}
+    engines: {node: '>= 18'}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -1888,9 +1932,21 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slashes@3.0.12:
+    resolution: {integrity: sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -1990,6 +2046,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  synckit@0.9.3:
+    resolution: {integrity: sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
@@ -2172,6 +2232,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@es-joy/jsdoccomment@0.46.0':
+    dependencies:
+      comment-parser: 1.4.1
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 4.0.0
+
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
@@ -2320,6 +2386,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pkgr/core@0.1.2': {}
 
   '@react-email/render@1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -2604,6 +2672,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  are-docs-informative@0.0.2: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -2801,6 +2871,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@4.1.1: {}
+
+  comment-parser@1.4.1: {}
 
   concat-map@0.0.1: {}
 
@@ -3006,6 +3078,8 @@ snapshots:
       math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3112,6 +3186,23 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-jsdoc@48.11.0(eslint@8.57.0):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.46.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 8.57.0
+      espree: 10.4.0
+      esquery: 1.7.0
+      parse-imports: 2.2.1
+      semver: 7.7.4
+      spdx-expression-parse: 4.0.0
+      synckit: 0.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0):
     dependencies:
       aria-query: 5.3.2
@@ -3164,6 +3255,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint@8.57.0:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.0)
@@ -3206,6 +3299,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -3675,6 +3774,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@4.0.0: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -3905,6 +4006,11 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-imports@2.2.1:
+    dependencies:
+      es-module-lexer: 1.7.0
+      slashes: 3.0.12
 
   parseley@0.12.1:
     dependencies:
@@ -4193,7 +4299,18 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slashes@3.0.12: {}
+
   source-map-js@1.2.1: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stable-hash@0.0.5: {}
 
@@ -4312,6 +4429,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  synckit@0.9.3:
+    dependencies:
+      '@pkgr/core': 0.1.2
+      tslib: 2.8.1
 
   tailwind-merge@2.6.1: {}
 

--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -16,10 +16,13 @@ export async function GET() {
         console.error('API Error fetching portfolio data:', error);
         console.error('Error stack:', error instanceof Error ? error.stack : 'No stack trace');
 
-        return NextResponse.json({ 
-            error: 'Failed to fetch portfolio data',
-            details: error instanceof Error ? error.message : 'Unknown error',
-            timestamp: new Date().toISOString()
-        }, { status: 500 });
+        return NextResponse.json(
+            {
+                error: 'Failed to fetch portfolio data',
+                details: error instanceof Error ? error.message : 'Unknown error',
+                timestamp: new Date().toISOString(),
+            },
+            { status: 500 },
+        );
     }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -242,7 +242,9 @@ export default function HomePage() {
                                     className={isNew ? 'animate-fade-in-up' : ''}
                                     style={
                                         isNew
-                                            ? ({ animationDelay: `${(index - prevVisibleCountRef.current) * 0.1}s` } as React.CSSProperties)
+                                            ? ({
+                                                  animationDelay: `${(index - prevVisibleCountRef.current) * 0.1}s`,
+                                              } as React.CSSProperties)
                                             : undefined
                                     }
                                 />

--- a/src/lib/costom-date.ts
+++ b/src/lib/costom-date.ts
@@ -6,9 +6,9 @@
 export function toDateString(yearMonth: string): string {
     const match = yearMonth.match(/(\d{4})年(\d{1,2})月/);
     if (!match) throw new Error(`Invalid format: ${yearMonth}`);
-    
+
     const year = match[1];
-    const month = match[2].padStart(2, "0");
-    
+    const month = match[2].padStart(2, '0');
+
     return `${year}/${month}/01`;
 }

--- a/src/lib/gcs.ts
+++ b/src/lib/gcs.ts
@@ -9,7 +9,10 @@ if (process.env.NODE_ENV === 'production') {
     storageConfig = {};
 } else if (process.env.NODE_ENV === 'development') {
     // Development environment
-    if (process.env.GOOGLE_APPLICATION_CREDENTIALS && process.env.GOOGLE_APPLICATION_CREDENTIALS !== '') {
+    if (
+        process.env.GOOGLE_APPLICATION_CREDENTIALS &&
+        process.env.GOOGLE_APPLICATION_CREDENTIALS !== ''
+    ) {
         storageConfig = {
             keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
         };
@@ -35,7 +38,7 @@ const jsonPath = process.env.GCS_JSON_PATH || 'json/navbar_intro.json';
 export async function getPortfolioDataFromGCS() {
     try {
         console.log(`GCS: Attempting to fetch from bucket: ${bucketName}, file: ${jsonPath}`);
-        
+
         const bucket = storage.bucket(bucketName);
         const file = bucket.file(jsonPath);
 
@@ -61,7 +64,9 @@ export async function getPortfolioDataFromGCS() {
             bucketName,
             jsonPath,
             projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
-            hasCredentials: !!(process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.GOOGLE_CLOUD_PRIVATE_KEY)
+            hasCredentials: !!(
+                process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.GOOGLE_CLOUD_PRIVATE_KEY
+            ),
         });
         throw new Error(
             `Failed to fetch portfolio data: ${error instanceof Error ? error.message : 'Unknown error'}`,


### PR DESCRIPTION
## 概要

`youtube-my-collection`（参考・read-only）の JSDoc 方針を本プロジェクトの ESLint 8 レガシー config へ移植し、`main` 宛 PR で **type-check / lint / format:check** を機械強制する CI を追加します。

## 変更点

### JSDoc Lint 導入
- `eslint-plugin-jsdoc@^48`（ESLint 8 互換の v48 系）を devDependency 追加
- `.eslintrc.json` の `overrides` で `src/**/*.{ts,tsx}` に JSDoc ルールを適用（`no-types` / `require-param` / `require-param-description` / `check-param-names` / `require-returns` / `require-returns-description` / `check-alignment` / `no-multi-asterisks`、`mode: typescript`）
- `.tsx`（React コンポーネント）は `require-returns` を除外（参考リポの設計思想を踏襲）

### CI ワークフロー
- `.github/workflows/ci.yml` を新規追加。`pull_request`（→ main）+ `workflow_dispatch` で `pnpm install --frozen-lockfile` → `type-check` → `lint` → `format:check` を実行

### Prettier スコープ調整
- `.prettierignore` を新規追加し、Prettier を **コード（`src/**` + ルート設定）に限定**（手書き docs / `pnpm-lock.yaml` / `.github` を除外）
- 未整形だった src 4ファイル（`route.ts` / `page.tsx` / `costom-date.ts` / `gcs.ts`）を prettier で整形（**シングルクォート正規化・行折り返し・末尾カンマのみ。ロジック変更なし**）

### ドキュメント
- `docs/08`（CI テスト統合の実装状況）/ `docs/09`（依存追加）/ `docs/10`（CI/CD §5.4）/ `.claude/rules/jsdoc.md` を実装状況に同期

## レビュー観点・確認事項

- **lint は「エラーで失敗・警告は許容」**（`next lint` 既定）にしています。既存の `gcs.ts` の `no-explicit-any` warning で CI を落とさないためです。警告もブロックしたい場合は `--max-warnings 0` を追加できます（その場合 `gcs.ts` の対応が先に必要）。
- **Prettier をコードに限定**しました。docs も整形対象にしたい場合は方針変更可能です。
- src 4ファイルの整形差分がロジックに影響しないことをご確認ください（`git diff --ignore-all-space` で確認済み）。

## 動作確認

ローカルで CI と同じ3チェックが green:
- ✅ `pnpm type-check`（`tsc --noEmit`）
- ✅ `pnpm lint`（ESLint + JSDoc、exit 0）
- ✅ `pnpm format:check`（"All matched files use Prettier code style!"）
- ✅ JSDoc ルール発火の検証（`.ts` で `no-types`/`require-returns`、`.tsx` で `require-returns` 抑制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)