### PR TITLE
test: E2E（Playwright + GCS コンテナ）を追加し portfolio ルートを動的化

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: E2E
+
+# E2E は UT/IT より重い（ブラウザ + build + Docker）ため、ci.yml とは別ワークフローに分離。
+on:
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch:
+
+jobs:
+    e2e:
+        name: E2E (Playwright + GCS container)
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  # testcontainers（→ undici@8）が Node >= 22.19 を要求するため 24 を使用。
+                  node-version: 24
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Playwright browser (chromium)
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Build
+              run: pnpm build
+
+            - name: Run E2E
+              run: pnpm test:e2e
+              env:
+                  # ephemeral な CI runner では reaper 不要。起動失敗による flaky を避けるため無効化。
+                  TESTCONTAINERS_RYUK_DISABLED: 'true'
+
+            - name: Upload Playwright report
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@
 # testing
 /coverage
 
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/README.md
+++ b/README.md
@@ -170,12 +170,14 @@ pnpm test          # Vitest（watch モード。ユニットテスト）
 pnpm test:run      # Vitest（1回実行。CI で使用）
 pnpm test:coverage # Vitest + カバレッジ計測
 pnpm test:it       # 統合テスト（要 Docker。fake-gcs-server コンテナ + MSW）
+pnpm test:e2e      # E2E（要 Docker + ビルド。Playwright + fake-gcs-server コンテナ）
 ```
 
-> ℹ️ テストは **Vitest + Testing Library** を使用。
+> ℹ️ テストは **Vitest + Testing Library**（UT/IT）と **Playwright**（E2E）を使用。
 > - **ユニットテスト**: ユーティリティ関数（`cn` / `toDateString` / `ContactFormSchema`）を実装済み。
 > - **統合テスト（`pnpm test:it`、要 Docker）**: GCS は [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) コンテナ（Testcontainers）で実データ経路を検証、Resend は [MSW](https://mswjs.io/) で HTTP をモック。`GET /api/portfolio`・`POST /api/contact`・`gcs` を対象。
-> - コンポーネント / E2E テストは今後拡充予定。テスト方針・全テストケース設計は [`docs/08-test-specification.md`](./docs/08-test-specification.md) を参照してください。
+> - **E2E（`pnpm test:e2e`、要 Docker + 事前 `pnpm build`）**: [Playwright](https://playwright.dev/) で実ブラウザからシナリオ検証。ポートフォリオ表示は fake-gcs-server コンテナの実データ、お問い合わせ送信・失敗系はブラウザで API をスタブ（Resend はエミュレータ無し）。正常/準正常/異常のシナリオを網羅。
+> - コンポーネントテストは今後拡充予定。テスト方針・全テストケース設計は [`docs/08-test-specification.md`](./docs/08-test-specification.md) を参照してください。
 
 ## 🎯 機能
 

--- a/docs/07-api-specification.md
+++ b/docs/07-api-specification.md
@@ -424,6 +424,8 @@ Resend API emails.send()
 
 ### 5.1 GET /api/portfolio のキャッシュ
 
+> **注**: この Route Handler は `export const dynamic = 'force-dynamic'` によりリクエスト時に実行され、都度 GCS からデータを取得する（ビルド時プリレンダーではない）。オリジンでの再取得を抑えるキャッシュは、下記 `Cache-Control` により CDN / 共有キャッシュ側で行う。
+
 ```
 Cache-Control: public, s-maxage=300, stale-while-revalidate=86400
 ```

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -96,7 +96,10 @@
   - GCS エミュレータ接続は `gcs.ts` の `GCS_API_ENDPOINT`（本番未設定）で `apiEndpoint` を上書きして実現。
   - この IT により、`resend.ts` が Resend の HTTP エラーを成功扱いする不具合を検出・修正した（`result.error` を検査するよう修正、`docs/11` #50）。
 
-一方、コンポーネントテストと Playwright による E2E は未実装。`@vitejs/plugin-react` は TypeScript 5.5.2 と非互換のため未導入で、React コンポーネントテストを追加する際に TS 5.5 互換の JSX 設定を別途整える必要がある。
+- **E2E テスト**: Playwright で `e2e/` にシナリオテストを実装済み、計 7 ケース（`pnpm test:e2e`）。**ポートフォリオ表示は fake-gcs-server コンテナの実データ**（本番ビルドのサーバを `GCS_API_ENDPOINT` でコンテナへ向ける）、**お問い合わせ送信・失敗系はブラウザで `page.route` により API をスタブ**（Resend はエミュレータ無し）。正常/準正常/異常を網羅。flaky 対策として CI では `retries: 2` + 失敗時 trace/screenshot/video。専用ワークフロー `.github/workflows/e2e.yml`（PR）で実行。要 Docker + `pnpm build`。
+  - E2E 導入時に、`/api/portfolio` がビルド時プリレンダーされ実行時に GCS を参照しない不具合を検出・修正した（`export const dynamic = 'force-dynamic'`、`docs/11` #51）。
+
+一方、コンポーネントテストは未実装。`@vitejs/plugin-react` は TypeScript 5.5.2 と非互換のため未導入で、React コンポーネントテストを追加する際に TS 5.5 互換の JSX 設定を別途整える必要がある。
 
 本仕様書では、プロジェクトの品質保証を目的として、目標とするテスト戦略とテストケースを包括的に定義する（未実装部分は今後の指針）。
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -150,8 +150,9 @@
 | @testing-library/jest-dom | ^6.9.1 | DOM アサーションマッチャー拡張 |
 | @testing-library/user-event | ^14.6.1 | ユーザー操作のシミュレーション |
 | jsdom | ^29.1.1 | テスト実行時のブラウザ環境エミュレーション |
-| testcontainers | ^12.0.4 | 統合テストで fake-gcs-server コンテナを起動（要 Docker） |
+| testcontainers | ^12.0.4 | 統合 / E2E テストで fake-gcs-server コンテナを起動（要 Docker） |
 | msw | ^2.15.0 | 統合テストで Resend の HTTP をモック |
+| @playwright/test | ^1.61.1 | E2E（実ブラウザ）テスト |
 
 ### 2.3 動作環境要件
 

--- a/docs/10-miscellaneous-specification.md
+++ b/docs/10-miscellaneous-specification.md
@@ -312,18 +312,24 @@ main（本番）
 
 ### 5.4 CI/CD パイプライン
 
-GitHub Actions は 2 本のワークフローで構成する。
+GitHub Actions は 3 本のワークフローで構成する。
 
 #### CI（品質チェック / `.github/workflows/ci.yml`）
 
 `main` 宛の **Pull Request**（および手動実行 `workflow_dispatch`）で以下を実行する。いずれか失敗するとチェックが赤くなり、マージ前に検知できる。
 
 1. コードのチェックアウト
-2. pnpm / Node.js 20 のセットアップ（依存キャッシュ有効）
+2. pnpm / Node.js 24 のセットアップ（依存キャッシュ有効。testcontainers→undici@8 が Node>=22.19 要求）
 3. 依存インストール（`pnpm install --frozen-lockfile`）
 4. 型チェック（`pnpm type-check` = `tsc --noEmit`）
 5. Lint（`pnpm lint` = ESLint + JSDoc ルール。エラーで失敗、警告は許容）
 6. フォーマットチェック（`pnpm format:check` = Prettier。`.prettierignore` で docs / lockfile / `.github` を除外し、コードのみ対象）
+7. ユニットテスト（`pnpm test:run` = Vitest）
+8. 統合テスト（`pnpm test:it` = Vitest。Testcontainers で fake-gcs-server 起動 + MSW。要 Docker）
+
+#### E2E（`.github/workflows/e2e.yml`）
+
+UT/IT より重い（ブラウザ + build + Docker）ため CI とは別ワークフローに分離。`main` 宛 PR（および `workflow_dispatch`）で、Playwright ブラウザ導入 → `pnpm build` → `pnpm test:e2e`（fake-gcs-server コンテナ + Playwright）を実行し、`playwright-report` をアーティファクト保存する。
 
 #### Deploy（`.github/workflows/deploy_to_googlecloud.yml`）
 

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -87,7 +87,8 @@
 | 29 | ユニットテスト実装（ユーティリティ関数） | 完了 | 高 | `cn()`（`src/utils/cn.test.ts`）/ `toDateString()`（`src/lib/costom-date.test.ts`）/ `ContactFormSchema`（`src/utils/validation.test.ts`）を実装。計 30 ケース（正常・準正常・異常、境界値含む）が PASS |
 | 30 | コンポーネントテスト実装 | 未着手 | 中 | atoms / molecules / organisms の描画テスト・インタラクションテスト。`@vitejs/plugin-react` が TS 5.5.2 と非互換のため、JSX 変換設定の整備が前提 |
 | 31 | API Route / データフェッチ統合テスト実装 | 完了 | 中 | 統合テスト（`*.integration.test.ts`）を実装。GCS は `fsouza/fake-gcs-server` コンテナ（Testcontainers）で実データ経路を検証、Resend は MSW で HTTP モック。`GET /api/portfolio`（`route.integration.test.ts`）/ `POST /api/contact`（同）/ `gcs`（`gcs.integration.test.ts`）を対象、計 10 ケース（正常・準正常・異常）。`vitest.integration.config.ts` + `pnpm test:it`、CI（`ci.yml`）で実行 |
-| 32 | E2E テスト導入（Playwright / Cypress） | 未着手 | 低 | `playwright.config.ts` がCI設定に言及されているが未導入 |
+| 32 | E2E テスト導入（Playwright） | 完了 | 低 | Playwright を導入し `e2e/` にシナリオテストを実装（`home` / `contact` / `error`、計 7 ケース、正常/準正常/異常）。ポートフォリオ表示は fake-gcs-server コンテナの実データ（`next start` を `GCS_API_ENDPOINT` で向ける）、送信・失敗系は `page.route` でスタブ。`playwright.config.ts` に retries/trace（flaky 対応）。専用ワークフロー `.github/workflows/e2e.yml`（PR）で実行 |
+| 51 | `/api/portfolio` がビルド時プリレンダーされ実行時に GCS を参照しない不具合修正 | 完了 | 中 | Route Handler に動的 API が無く静的プリレンダーされていたため、データがビルド時点で固定され（かつビルドに GCS 認証が必要）、実行時の GCS 取得・キャッシュ（docs/07 §5）が機能していなかった。E2E 導入時に検出し `export const dynamic = 'force-dynamic'` を追加。実行時に GCS を取得し、キャッシュは CDN 側の `Cache-Control` に委ねる |
 
 ### 2.2 パフォーマンス最適化
 

--- a/e2e/contact.spec.ts
+++ b/e2e/contact.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+const validInput = {
+    name: '山田太郎',
+    email: 'taro@example.com',
+    message: 'E2E テストのお問い合わせです。よろしくお願いします。',
+};
+
+// ページ表示自体は GCS コンテナの実データを使う。送信の成否のみブラウザ側でスタブする
+// （Resend にはエミュレータが無く、E2E で実メール送信もできないため）。
+test.beforeEach(async ({ page }) => {
+    await page.route(/placehold\.co/, (route) => route.abort());
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Contact', exact: true })).toBeVisible();
+});
+
+// フォームへ有効値を入力する。
+async function fillValidForm(page: import('@playwright/test').Page) {
+    await page.locator('input[name="name"]').fill(validInput.name);
+    await page.locator('input[name="email"]').fill(validInput.email);
+    await page.locator('textarea[name="message"]').fill(validInput.message);
+}
+
+test.describe('お問い合わせフォーム', () => {
+    // --- 準正常系（HTML の required は満たすが zod のクライアントバリデーションで弾く。API は呼ばれない）---
+    // 注: 空欄はブラウザのネイティブ required 検証が submit をブロックするため、
+    // zod のカスタムメッセージは「非空だが短すぎる」入力でのみ観測できる。
+    test('短すぎる入力はバリデーションエラーが表示される', async ({ page }) => {
+        await page.locator('input[name="name"]').fill('a'); // 1 文字（min 2 違反）
+        await page.locator('input[name="email"]').fill('taro@example.com'); // 有効
+        await page.locator('textarea[name="message"]').fill('短い文'); // 10 文字未満
+
+        await page.getByRole('button', { name: '上記内容で送信する' }).click();
+
+        await expect(page.getByText('お名前は2文字以上で入力してください')).toBeVisible();
+        await expect(
+            page.getByText('お問い合わせ内容は10文字以上で入力してください'),
+        ).toBeVisible();
+    });
+
+    // --- 正常系（/api/contact を 200 でスタブ）---
+    test('正常入力で送信すると完了画面が表示される', async ({ page }) => {
+        await page.route('**/api/contact', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ success: true, message: 'ok', messageId: 'e2e-id' }),
+            }),
+        );
+
+        await fillValidForm(page);
+        await page.getByRole('button', { name: '上記内容で送信する' }).click();
+
+        await expect(page.getByRole('heading', { name: '送信完了' })).toBeVisible();
+        await expect(page.getByText('お問い合わせありがとうございます。')).toBeVisible();
+    });
+
+    // --- 異常系（/api/contact が 500）---
+    test('送信が失敗するとエラーメッセージが表示される', async ({ page }) => {
+        await page.route('**/api/contact', (route) =>
+            route.fulfill({
+                status: 500,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    error: 'メールの送信に失敗しました。しばらくしてからもう一度お試しください。',
+                }),
+            }),
+        );
+
+        await fillValidForm(page);
+        await page.getByRole('button', { name: '上記内容で送信する' }).click();
+
+        await expect(
+            page.getByText('メールの送信に失敗しました。しばらくしてからもう一度お試しください。'),
+        ).toBeVisible();
+    });
+});

--- a/e2e/error.spec.ts
+++ b/e2e/error.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ポートフォリオ取得失敗（異常系）', () => {
+    test('取得失敗時はエラー画面と Reload ボタンが表示される', async ({ page }) => {
+        await page.route(/placehold\.co/, (route) => route.abort());
+        // /api/portfolio を 500 にしてデータ取得失敗を再現する。
+        await page.route('**/api/portfolio', (route) =>
+            route.fulfill({
+                status: 500,
+                contentType: 'application/json',
+                body: JSON.stringify({ error: 'Failed to fetch portfolio data' }),
+            }),
+        );
+
+        await page.goto('/');
+
+        await expect(page.getByText('Failed to load portfolio data')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Reload Page' })).toBeVisible();
+    });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,38 @@
+import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers';
+import { Storage } from '@google-cloud/storage';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const EMULATOR_PORT = 4443;
+const BUCKET = 'e2e-bucket';
+const JSON_PATH = 'json/portfolio.json';
+
+declare global {
+    // eslint-disable-next-line no-var
+    var __E2E_GCS_CONTAINER__: StartedTestContainer | undefined;
+}
+
+/**
+ * E2E 全体のセットアップ。fake-gcs-server を固定ポートで起動し、
+ * 同梱のデモデータ（sample.example.json）をバケットへ投入する。
+ * 起動したサーバ（next start）はこのバケットからポートフォリオを取得する。
+ */
+export default async function globalSetup() {
+    const container = await new GenericContainer('fsouza/fake-gcs-server:latest')
+        .withExposedPorts({ container: EMULATOR_PORT, host: EMULATOR_PORT })
+        .withCommand(['-scheme', 'http', '-port', String(EMULATOR_PORT), '-backend', 'memory'])
+        .withWaitStrategy(Wait.forListeningPorts())
+        .start();
+
+    const endpoint = `http://127.0.0.1:${EMULATOR_PORT}`;
+    const portfolio = readFileSync(path.resolve(process.cwd(), 'sample.example.json'), 'utf-8');
+
+    const storage = new Storage({ apiEndpoint: endpoint, projectId: 'e2e-test' });
+    await storage.createBucket(BUCKET);
+    await storage
+        .bucket(BUCKET)
+        .file(JSON_PATH)
+        .save(portfolio, { resumable: false, contentType: 'application/json' });
+
+    globalThis.__E2E_GCS_CONTAINER__ = container;
+}

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,7 @@
+/**
+ * E2E 全体のティアダウン。globalSetup で起動した GCS エミュレータコンテナを停止する。
+ */
+export default async function globalTeardown() {
+    await globalThis.__E2E_GCS_CONTAINER__?.stop();
+    globalThis.__E2E_GCS_CONTAINER__ = undefined;
+}

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// 外部画像（placehold.co）は E2E をヘルメティックに保つため中断する。
+test.beforeEach(async ({ page }) => {
+    await page.route(/placehold\.co/, (route) => route.abort());
+});
+
+test.describe('ホーム（正常系：GCS コンテナの実データ経路）', () => {
+    test('全セクションとフッターが表示される', async ({ page }) => {
+        await page.goto('/');
+
+        // Hero はデータ取得完了後にのみ描画される＝GCS コンテナからの取得成功を意味する。
+        await expect(
+            page.getByRole('heading', { name: 'Solving Problems with Technology' }),
+        ).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'About', exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Career', exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Skills', exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Contact', exact: true })).toBeVisible();
+
+        // フッターの著作権（データ駆動）
+        await expect(page.getByText('© 2024 TechProfile Pro. All rights reserved.')).toBeVisible();
+    });
+
+    test('ヘッダーナビで Contact セクションへスクロールする', async ({ page }) => {
+        await page.goto('/');
+        await expect(
+            page.getByRole('heading', { name: 'Solving Problems with Technology' }),
+        ).toBeVisible();
+
+        await page.locator('header').getByRole('button', { name: 'Contact' }).click();
+        await expect(page.locator('#contact')).toBeInViewport({ timeout: 10_000 });
+    });
+
+    test('Skills の「and more...」で全カードが表示される', async ({ page }) => {
+        await page.goto('/');
+
+        const moreButton = page.getByRole('button', { name: 'and more...' });
+        await expect(moreButton).toBeVisible();
+        await moreButton.click();
+
+        // 12 件（初期 9 + 6）→ 全表示 → ボタン消滅 + skills_more テキスト。
+        await expect(moreButton).toBeHidden();
+        await expect(page.getByText('ほかにも幅広い技術スタックに対応しています。')).toBeVisible();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "test": "vitest",
         "test:run": "vitest run",
         "test:coverage": "vitest run --coverage",
-        "test:it": "vitest run --config vitest.integration.config.ts"
+        "test:it": "vitest run --config vitest.integration.config.ts",
+        "test:e2e": "playwright test"
     },
     "dependencies": {
         "@google-cloud/storage": "^7.16.0",
@@ -29,6 +30,7 @@
         "zod": "^3.23.8"
     },
     "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// GCS エミュレータは固定ポートで起動し、webServer(env) から静的に参照できるようにする。
+const GCS_EMULATOR_PORT = 4443;
+
+export default defineConfig({
+    testDir: './e2e',
+    testMatch: '**/*.spec.ts',
+    fullyParallel: false,
+    forbidOnly: !!process.env.CI,
+    // flaky 対応: CI ではリトライし、失敗時のみ trace / screenshot / video を保存する。
+    retries: process.env.CI ? 2 : 0,
+    workers: 1,
+    timeout: 30_000,
+    reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+    globalSetup: './e2e/global-setup.ts',
+    globalTeardown: './e2e/global-teardown.ts',
+    use: {
+        baseURL: 'http://127.0.0.1:3000',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+    },
+    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+    // 本番ビルドのサーバを GCS エミュレータへ向けて起動する（要 `pnpm build` 済み）。
+    webServer: {
+        command: 'pnpm start',
+        url: 'http://127.0.0.1:3000',
+        timeout: 120_000,
+        reuseExistingServer: !process.env.CI,
+        env: {
+            GCS_API_ENDPOINT: `http://127.0.0.1:${GCS_EMULATOR_PORT}`,
+            GCS_PRIVATE_BUCKET_NAME: 'e2e-bucket',
+            GCS_JSON_PATH: 'json/portfolio.json',
+        },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.1.1
       next:
         specifier: 14.2.5
-        version: 14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -39,6 +39,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -469,6 +472,11 @@ packages:
   '@pkgr/core@0.1.2':
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1774,6 +1782,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2599,6 +2612,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3782,6 +3805,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.2': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -5239,6 +5266,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5915,7 +5945,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.5(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
@@ -5936,6 +5966,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.5
       '@next/swc-win32-ia32-msvc': 14.2.5
       '@next/swc-win32-x64-msvc': 14.2.5
+      '@playwright/test': 1.61.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -6082,6 +6113,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getPortfolioDataServer } from '@/lib/data-server';
 
+// GCS 上の可変データをリクエスト時に取得する（ビルド時プリレンダーだと
+// データがビルド時点で固定され、ビルドに GCS 認証も必要になるため）。
+// エッジ/CDN 側のキャッシュはレスポンスの Cache-Control(s-maxage=300) で行う。
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
     try {
         console.log('API: Starting portfolio data fetch...');


### PR DESCRIPTION
## 概要

E2E（シナリオ）テストを導入します。方針は **GCS コンテナ + `next start`（本物のデータ経路）**。DB は存在しないためコンテナは fake-gcs-server。お問い合わせ送信・失敗系は Resend エミュレータが無いためブラウザで `page.route` によりスタブ。E2E は重い（ブラウザ + build + Docker）ため**専用ワークフロー**に分離します。`docs/11` #32 に対応。

## 変更点

### E2E 基盤
- `@playwright/test@1.61`（+ chromium）
- `playwright.config.ts`: `webServer` で `next start` を `GCS_API_ENDPOINT`（固定ポート 4443）へ向けて起動、`globalSetup`/`globalTeardown` で fake-gcs-server コンテナ起動 + seed（`sample.example.json`）
- **flaky 対応**: CI `retries: 2` + 失敗時 `trace`/`screenshot`/`video`
- `test:e2e` スクリプト、`.gitignore` に Playwright 生成物

### シナリオテスト（7 ケース・全 PASS）
| ファイル | 内容 | 分類 |
|---|---|---|
| `home.spec.ts` | 全セクション表示（**GCS コンテナの実データ**）/ ナビでスクロール / Skills「and more」 | 正常 |
| `contact.spec.ts` | 短すぎ入力→バリデーション / 送信成功→完了画面 / 送信500→エラー | 準正常 / 正常 / 異常 |
| `error.spec.ts` | `/api/portfolio` 500→エラー画面 + Reload | 異常 |

### E2E が検出した不具合を修正（要レビュー）
- **`fix(portfolio)`**: `/api/portfolio` が動的 API を持たず**ビルド時プリレンダー**され、実行時に GCS を参照していなかった（`curl` で確認：エミュレータではなくビルド時ベイクの本番実データが返っていた）。docs/07 の「実行時 GCS 取得 + 5分キャッシュ」と乖離し、かつ**ビルドに GCS 認証が必要**になっていた。→ `export const dynamic = 'force-dynamic'` を追加。実行時に GCS 取得（キャッシュは CDN の `Cache-Control` に委譲）、ビルドの GCS 依存も解消。→ `docs/11` #51。

### CI
- `.github/workflows/e2e.yml`（PR、Node 24）: browsers 導入 → `pnpm build` → `pnpm test:e2e` → `playwright-report` をアーティファクト保存。

### ドキュメント
README / docs/07（route dynamic）/ 08（E2E 状況）/ 09（依存）/ 10（CI 3 ワークフロー・Node 24 反映）/ 11（#32 完了・#51 修正）を同期。

## レビュー観点・確認事項

- **`route.ts` の `force-dynamic` は本番挙動の変更**（静的ベイク → 実行時 GCS 取得）。docs 準拠かつビルドの GCS 依存解消という改善ですが、本番はリクエストごとに GCS アクセス（CDN 前段でキャッシュ想定）になる点をご確認ください。
- **空欄フォームはブラウザのネイティブ `required` 検証**が submit をブロックし zod のカスタムメッセージが出ないため、準正常系は「非空だが短すぎる入力」で zod バリデーションを検証しています（実挙動に忠実）。
- E2E は Docker + `pnpm build` 前提（CI で自動化済み）。この PR の Actions（E2E ワークフロー）で Testcontainers + ブラウザが動くかご確認ください。

## 動作確認（実 Docker）

- ✅ type-check / ✅ lint / ✅ format:check
- ✅ `pnpm test:run`（UT 33）/ ✅ `pnpm test:it`（IT 10）
- ✅ `pnpm test:e2e`（**E2E 7 passed**、fake-gcs-server 起動 + 実ブラウザ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)