### PR TITLE
chore: 主要コマンドを集約する Makefile を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,122 @@
+# TechProfile Pro - Makefile
+#
+# pnpm スクリプト・セットアップ・Docker・Terraform の主要コマンドを集約するタスクランナー。
+# 実体は package.json の scripts / README の手順に委譲する薄いラッパー。
+# 使い方: `make` または `make help` でターゲット一覧を表示。
+
+# ---- 設定 --------------------------------------------------------------
+# パッケージマネージャは pnpm に固定（npm / yarn は使用しない）
+PNPM        := pnpm
+# Docker イメージ名（README のローカルビルド確認に合わせる）
+IMAGE       := techprofile-pro
+# Terraform 作業ディレクトリ
+TF_DIR      := terraform
+
+# 全ターゲットはファイルを生成しない（同名ファイルがあっても常に実行する）
+.PHONY: help setup install sample dev build start lint format format-check \
+        type-check test test-run test-coverage test-it test-e2e check \
+        docker-build docker-run tf-init tf-plan tf-apply clean
+
+# デフォルトターゲット: ヘルプ表示
+.DEFAULT_GOAL := help
+
+# ---- ヘルプ ------------------------------------------------------------
+## help: このヘルプを表示する
+help:
+	@echo "TechProfile Pro - 利用可能なコマンド:"
+	@echo ""
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'
+
+# ---- セットアップ ------------------------------------------------------
+## setup: 依存関係のインストールと表示データ(sample.json)を用意する
+setup: install sample
+
+## install: 依存関係をインストールする (pnpm install)
+install:
+	$(PNPM) install
+
+## sample: sample.example.json を sample.json にコピーする（未作成時のみ）
+sample:
+	@test -f sample.json || cp sample.example.json sample.json
+	@echo "sample.json を用意しました"
+
+# ---- 開発 --------------------------------------------------------------
+## dev: 開発サーバーを起動する (next dev)
+dev:
+	$(PNPM) dev
+
+## build: プロダクションビルドを実行する (next build)
+build:
+	$(PNPM) build
+
+## start: プロダクションサーバーを起動する (next start)
+start:
+	$(PNPM) start
+
+# ---- 品質チェック ------------------------------------------------------
+## lint: ESLint を実行する（JSDoc ルール含む）
+lint:
+	$(PNPM) lint
+
+## format: Prettier で整形する
+format:
+	$(PNPM) format
+
+## format-check: Prettier の整形チェック（差分のみ）
+format-check:
+	$(PNPM) format:check
+
+## type-check: TypeScript の型チェック (tsc --noEmit)
+type-check:
+	$(PNPM) type-check
+
+## check: lint + format-check + type-check + test-run をまとめて実行する
+check: lint format-check type-check test-run
+
+# ---- テスト ------------------------------------------------------------
+## test: ユニットテストを watch モードで実行する (vitest)
+test:
+	$(PNPM) test
+
+## test-run: ユニットテストを 1 回実行する (vitest run)
+test-run:
+	$(PNPM) test:run
+
+## test-coverage: ユニットテスト + カバレッジ計測
+test-coverage:
+	$(PNPM) test:coverage
+
+## test-it: 統合テストを実行する（要 Docker: fake-gcs-server + MSW）
+test-it:
+	$(PNPM) test:it
+
+## test-e2e: E2E テストを実行する（要 Docker + 事前 build。Playwright）
+test-e2e:
+	$(PNPM) test:e2e
+
+# ---- Docker ------------------------------------------------------------
+## docker-build: Docker イメージをビルドする
+docker-build:
+	docker build -t $(IMAGE) .
+
+## docker-run: ビルド済みイメージをローカル起動する (http://localhost:3000)
+docker-run:
+	docker run --rm -p 3000:3000 $(IMAGE)
+
+# ---- Terraform ---------------------------------------------------------
+## tf-init: Terraform を初期化する
+tf-init:
+	cd $(TF_DIR) && terraform init
+
+## tf-plan: Terraform の変更計画を表示する
+tf-plan:
+	cd $(TF_DIR) && terraform plan
+
+## tf-apply: Terraform の変更を適用する
+tf-apply:
+	cd $(TF_DIR) && terraform apply
+
+# ---- クリーンアップ ----------------------------------------------------
+## clean: ビルド成果物・テスト成果物を削除する
+clean:
+	rm -rf .next coverage playwright-report test-results

--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ pnpm test:it       # 統合テスト（要 Docker。fake-gcs-server コンテナ
 pnpm test:e2e      # E2E（要 Docker + ビルド。Playwright + fake-gcs-server コンテナ）
 ```
 
+> 🛠️ **Makefile も同梱**しています。上記スクリプトや Docker / Terraform / セットアップ手順を短いコマンドで実行できます。`make`（または `make help`）でターゲット一覧を表示します。
+>
+> ```bash
+> make setup   # pnpm install + sample.json 用意（= クイックスタートの 2〜3）
+> make dev     # 開発サーバー起動
+> make check   # lint + format:check + type-check + test:run をまとめて実行
+> make test-it # 統合テスト（要 Docker）
+> ```
+
 > ℹ️ テストは **Vitest + Testing Library**（UT/IT）と **Playwright**（E2E）を使用。
 > - **ユニットテスト**: ユーティリティ関数（`cn` / `toDateString` / `ContactFormSchema`）を実装済み。
 > - **統合テスト（`pnpm test:it`、要 Docker）**: GCS は [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) コンテナ（Testcontainers）で実データ経路を検証、Resend は [MSW](https://mswjs.io/) で HTTP をモック。`GET /api/portfolio`・`POST /api/contact`・`gcs` を対象。


### PR DESCRIPTION
## 概要

pnpm スクリプト・セットアップ・Docker・Terraform の主要コマンドを集約する `Makefile` を追加しました。実体はすべて既存の `package.json` scripts / README 手順へ委譲する薄いラッパーです。

## 変更点

- `Makefile` を新規追加（自己文書化された `help` をデフォルトターゲットに設定）
  - セットアップ: `setup`（install + sample.json）/ `install` / `sample`
  - 開発: `dev` / `build` / `start`
  - 品質: `lint` / `format` / `format-check` / `type-check` / `check`（一括）
  - テスト: `test` / `test-run` / `test-coverage` / `test-it` / `test-e2e`
  - Docker: `docker-build` / `docker-run` ／ Terraform: `tf-init` / `tf-plan` / `tf-apply` ／ `clean`
- `README.md`「利用可能なスクリプト」に Makefile の案内を追記（ドキュメント影響マップ: スクリプト・利用方法の変更 → README.md）

## 確認してほしいこと

- `make help` でターゲット一覧が表示されること
- `make setup` が `pnpm install` + `sample.json` 用意（既存時は上書きしない）として機能すること
- `make check` が lint / format:check / type-check / test:run を一括実行すること
- 動作確認: `make help` の表示と主要ターゲットの `make -n`（ドライラン）でコマンド展開が正しいことを検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)